### PR TITLE
Added support for 64-bit immediates in IDA pseudocode

### DIFF
--- a/hashdb.py
+++ b/hashdb.py
@@ -725,6 +725,8 @@ def set_xor_key():
     global HASHDB_USE_XOR
     global HASHDB_XOR_VALUE
     xor_value = parse_highlighted_value("ERROR: Not a valid xor selection\n")
+    if xor_value is None:
+        return False
     HASHDB_XOR_VALUE = xor_value
     HASHDB_USE_XOR = True
     idaapi.msg("XOR key set: %s\n" % hex(xor_value))
@@ -746,6 +748,8 @@ def hash_lookup():
     # If algorithm not selected pop up box to select
     # Lookup hash with algorithm 
     hash_value = parse_highlighted_value("ERROR: Not a valid hash selection\n")
+    if hash_value is None:
+        return
     # If there is no algorithm selected pop settings window
     if HASHDB_ALGORITHM == None:
         warn_result = idaapi.warning("Please select a hash algorithm before using HashDB.")
@@ -950,6 +954,8 @@ def hunt_algorithm():
     global HASHDB_XOR_VALUE
     # Get selected hash
     hash_value = parse_highlighted_value("ERROR: Not a valid hash selection\n", False)
+    if hash_value is None:
+        return
     # If xor is set then xor hash first
     if HASHDB_USE_XOR:
         hash_value ^=HASHDB_XOR_VALUE

--- a/hashdb.py
+++ b/hashdb.py
@@ -730,8 +730,22 @@ def hash_lookup():
     if identifier == None:
         idaapi.msg("ERROR: Not a valid hash selection\n")
         return
-    elif ('h' in identifier) or ('0x' in identifier):
-        hash_value = int(identifier.replace('h','').replace('u',''),16)
+
+    # 64-bit immediates end with "i64", we need to strip these suffixes to parse the actual value
+    is_hex = False
+    if identifier.endswith('h'): # IDA View
+        identifier = identifier[:-1]
+        is_hex = True
+    else: # Pseudocode
+        if identifier.endswith('ui64'): # unsigned type
+            identifier = identifier[:-4]
+        elif identifier.endswith('i64'):
+            identifier = identifier[:-3]
+        if identifier.startswith('0x'):
+            is_hex = True
+    
+    if is_hex:
+        hash_value = int(identifier,16)
         idaapi.msg("Hex value found %s\n" % hex(hash_value))
     else:
         hash_value = int(identifier)

--- a/hashdb.py
+++ b/hashdb.py
@@ -741,6 +741,8 @@ def hash_lookup():
             identifier = identifier[:-4]
         elif identifier.endswith('i64'):
             identifier = identifier[:-3]
+        elif identifier.endswith('u'):
+            identifier = identifier[:-1]
         if identifier.startswith('0x'):
             is_hex = True
     


### PR DESCRIPTION
For 64-bit binaries the equivalent immediate values generally end with `i64` or `ui64`.
As a result [this code](https://github.com/OALabs/hashdb-ida/blob/80b42d6223633b89bec191741c3681b625a836d4/hashdb.py#L734) would break when parsing the value using `int(identifier)`.

This commit should solve the problem.

**Warning:**
- I'm not sure if this code will be compliant with Python 2.7 (regarding future support).