### PR TITLE
Added support for 64-bit enum values

### DIFF
--- a/hashdb.py
+++ b/hashdb.py
@@ -71,7 +71,7 @@ HASHDB_USE_XOR = False
 HASHDB_XOR_VALUE = 0
 HASHDB_ALGORITHM = None
 HASHDB_ALGORITHM_SIZE = 0
-ENUM_NAME = "hashdb_strings"
+ENUM_PREFIX = "hashdb_strings"
 NETNODE_NAME = "$hashdb"
 
 #--------------------------------------------------------------------------
@@ -245,7 +245,7 @@ def load_settings():
     global HASHDB_USE_XOR
     global HASHDB_XOR_VALUE 
     global HASHDB_ALGORITHM
-    global ENUM_NAME
+    global ENUM_PREFIX
     global NETNODE_NAME
     node = ida_netnode.netnode(NETNODE_NAME)
     if ida_netnode.exist(node):
@@ -262,8 +262,8 @@ def load_settings():
             successful = set_algorithm(node.hashstr("HASHDB_ALGORITHM"), node.hashstr("HASHDB_ALGORITHM_SIZE"))
             if not successful:
                 idaapi.msg("HashDB failed to set the algorithm when parsing the saved config!\n")
-        if bool(node.hashstr("ENUM_NAME")):
-            ENUM_NAME = node.hashstr("ENUM_NAME")
+        if bool(node.hashstr("ENUM_PREFIX")):
+            ENUM_PREFIX = node.hashstr("ENUM_PREFIX")
         idaapi.msg("HashDB configuration loaded!\n")
     else:
         idaapi.msg("No saved HashDB configuration\n")
@@ -275,7 +275,7 @@ def save_settings():
     global HASHDB_USE_XOR
     global HASHDB_XOR_VALUE 
     global HASHDB_ALGORITHM
-    global ENUM_NAME
+    global ENUM_PREFIX
     global NETNODE_NAME
     node = ida_netnode.netnode()
     if node.create(NETNODE_NAME):
@@ -289,8 +289,8 @@ def save_settings():
             node.hashset_buf("HASHDB_ALGORITHM", str(HASHDB_ALGORITHM))
         if HASHDB_ALGORITHM != None:
             node.hashset_buf("HASHDB_ALGORITHM_SIZE", str(HASHDB_ALGORITHM_SIZE))
-        if ENUM_NAME != None:
-            node.hashset_buf("ENUM_NAME", str(ENUM_NAME))
+        if ENUM_PREFIX != None:
+            node.hashset_buf("ENUM_PREFIX", str(ENUM_PREFIX))
         idaapi.msg("HashDB settings saved\n")
     else:
         idaapi.msg("ERROR: Unable to save HashDB settings\n")
@@ -339,7 +339,7 @@ HashDB Settings
 
 {FormChangeCb}
 <##API URL          :{iServer}>
-<##Enum Name        :{iEnum}>
+<##Enum Prefix      :{iEnum}>
 <Enable XOR:{rXor}>{cXorGroup}>  |  <##:{iXor}>(hex)
 <Select algorithm :{cAlgoChooser}><Refresh Algorithms:{iBtnRefresh}>
 
@@ -388,7 +388,7 @@ HashDB Settings
 
     @staticmethod
     def show(api_url="https://hashdb.openanalysis.net",
-             enum_name="hashdb_strings",
+             enum_prefix="hashdb_strings",
              use_xor=False,
              xor_value=0,
              algorithms=[]):
@@ -396,14 +396,14 @@ HashDB Settings
         global HASHDB_USE_XOR
         global HASHDB_XOR_VALUE
         global HASHDB_ALGORITHM
-        global ENUM_NAME
+        global ENUM_PREFIX
         # Sort the algorithms
         sorted_algorithms = sorted(algorithms, key = lambda algorithm: algorithm[0].lower())
         f = hashdb_settings_t(sorted_algorithms)
         f, args = f.Compile()
         # Set default values
         f.iServer.value = api_url
-        f.iEnum.value = enum_name
+        f.iEnum.value = enum_prefix
         if use_xor:
             f.rXor.checked = True
         else:
@@ -416,7 +416,7 @@ HashDB Settings
             HASHDB_USE_XOR = f.rXor.checked
             HASHDB_XOR_VALUE = f.iXor.value
             HASHDB_API_URL = f.iServer.value
-            ENUM_NAME = f.iEnum.value
+            ENUM_PREFIX = f.iEnum.value
             # Check if algorithm is selected
             if f.cAlgoChooser.selection == None:
                 # No algorithm selected bail!
@@ -628,11 +628,15 @@ Do you want to import all function hashes from this module?
 #--------------------------------------------------------------------------
 # IDA helper functions
 #--------------------------------------------------------------------------
-def add_enums(enum_name, hash_list, enum_size = 0):
+def add_enums(enum_name, hash_list, enum_member_prefix = None, enum_size = 0):
     '''
     Add a list of string,hash pairs to enum.
     hash_list = [(string1,hash1),(string2,hash2)]
     '''
+    # Resolve the enum member prefix
+    if enum_member_prefix is None:
+        global HASHDB_ALGORITHM
+        enum_member_prefix = HASHDB_ALGORITHM
     # Resolve the enum size
     if not enum_size:
         global HASHDB_ALGORITHM_SIZE
@@ -650,9 +654,18 @@ def add_enums(enum_name, hash_list, enum_size = 0):
     if not ida_enum.set_enum_width(enum_id, enum_size):
         return None
     
-    for element in hash_list:
-        ida_enum.add_enum_member(enum_id, element[0], element[1])
+    for member_name, value in hash_list:
+        # if not enum_member_prefix was specifically chosen to allow empty prefixes
+        ida_enum.add_enum_member(enum_id, member_name if not enum_member_prefix else enum_member_prefix + '_' + member_name, value)
     return enum_id
+
+
+def generate_enum_name(prefix: str) -> str:
+    """
+    Generates an enum name from a prefix
+    """
+    global HASHDB_ALGORITHM
+    return prefix + '_' + HASHDB_ALGORITHM
 
 
 def make_const_enum(enum_id, hash_value):
@@ -777,16 +790,16 @@ def global_settings():
     global HASHDB_USE_XOR
     global HASHDB_XOR_VALUE
     global HASHDB_ALGORITHM
-    global ENUM_NAME
+    global ENUM_PREFIX
     if HASHDB_ALGORITHM != None:
         algorithms = [[HASHDB_ALGORITHM, str(HASHDB_ALGORITHM_SIZE)]]
     else:
         algorithms = []
     settings_results = hashdb_settings_t.show(api_url=HASHDB_API_URL, 
-                                                  enum_name=ENUM_NAME,
-                                                  use_xor=HASHDB_USE_XOR,
-                                                  xor_value=HASHDB_XOR_VALUE,
-                                                  algorithms=algorithms)
+                                              enum_prefix=ENUM_PREFIX,
+                                              use_xor=HASHDB_USE_XOR,
+                                              xor_value=HASHDB_XOR_VALUE,
+                                              algorithms=algorithms)
     if settings_results:
         idaapi.msg("HashDB configured successfully!\nHASHDB_API_URL: %s\nHASHDB_USE_XOR: %s\nHASHDB_XOR_VALUE: %s\nHASHDB_ALGORITHM: %s\nHASHDB_ALGORITHM_SIZE: %s\n" % 
                    (HASHDB_API_URL, HASHDB_USE_XOR, hex(HASHDB_XOR_VALUE), HASHDB_ALGORITHM, HASHDB_ALGORITHM_SIZE))
@@ -866,7 +879,7 @@ def hash_lookup():
     global HASHDB_USE_XOR
     global HASHDB_XOR_VALUE
     global HASHDB_ALGORITHM
-    global ENUM_NAME
+    global ENUM_PREFIX
     # If algorithm not selected pop up box to select
     # Lookup hash with algorithm 
     hash_value = parse_highlighted_value("ERROR: Not a valid hash selection\n")
@@ -876,7 +889,7 @@ def hash_lookup():
     if HASHDB_ALGORITHM == None:
         warn_result = idaapi.warning("Please select a hash algorithm before using HashDB.")
         settings_results = hashdb_settings_t.show(api_url=HASHDB_API_URL, 
-                                                  enum_name=ENUM_NAME,
+                                                  enum_prefix=ENUM_PREFIX,
                                                   use_xor=HASHDB_USE_XOR,
                                                   xor_value=HASHDB_XOR_VALUE,
                                                   algorithms=[])
@@ -928,10 +941,10 @@ def hash_lookup():
         string_value = 'empty_string'
     idaapi.msg("Hash match found: %s\n" % string_value)
     # Add hash to enum
-    enum_id = add_enums(ENUM_NAME, [(string_value,hash_value)])
+    enum_id = add_enums(generate_enum_name(ENUM_PREFIX), [(string_value,hash_value)])
     # Exit if we can't create the enum
     if enum_id == None:
-        idaapi.msg("ERROR: Unable to create or find enum: %s\n" % ENUM_NAME)
+        idaapi.msg("ERROR: Unable to create or find enum: %s\n" % generate_enum_name(ENUM_PREFIX))
         return
     # If the hash was pulled from the disassembly window
     # make the constant an enum 
@@ -955,9 +968,9 @@ def hash_lookup():
                     else:
                         enum_list.append((function_entry.get('string',{}).get('api',''),function_entry.get('hash',0)))
                 # Add hashes to enum
-                enum_id = add_enums(ENUM_NAME, enum_list)
+                enum_id = add_enums(generate_enum_name(ENUM_PREFIX), enum_list)
                 if enum_id == None:
-                    idaapi.msg("ERROR: Unable to create or find enum: %s\n" % ENUM_NAME)
+                    idaapi.msg("ERROR: Unable to create or find enum: %s\n" % generate_enum_name(ENUM_PREFIX))
                 else:
                     idaapi.msg("Added %d hashes for module %s\n" % (len(enum_list),module_name))
             except Exception as e:
@@ -980,7 +993,7 @@ def hash_scan(convert_values = True):
     global HASHDB_USE_XOR
     global HASHDB_XOR_VALUE
     global HASHDB_ALGORITHM
-    global ENUM_NAME
+    global ENUM_PREFIX
     # Only scan for data in the dissassembler
     if ida_kernwin.get_viewer_place_type(ida_kernwin.get_current_viewer()) != ida_kernwin.TCCPT_IDAPLACE:
         idaapi.msg("ERROR: Scan only available in dissassembler. \n")
@@ -996,7 +1009,7 @@ def hash_scan(convert_values = True):
     if HASHDB_ALGORITHM == None:
         warn_result = idaapi.warning("Please select a hash algorithm before using HashDB.")
         settings_results = hashdb_settings_t.show(api_url=HASHDB_API_URL, 
-                                                  enum_name=ENUM_NAME,
+                                                  enum_name=generate_enum_name(ENUM_PREFIX),
                                                   use_xor=HASHDB_USE_XOR,
                                                   xor_value=HASHDB_XOR_VALUE,
                                                   algorithms=[])
@@ -1065,10 +1078,10 @@ def hash_scan(convert_values = True):
                 string_value = 'empty_string'
             idaapi.msg("Hash match found: %s\n" % string_value)
             # Add hash to enum
-            enum_id = add_enums(ENUM_NAME, [(string_value,hash_value)])
+            enum_id = add_enums(generate_enum_name(ENUM_PREFIX), [(string_value,hash_value)])
             # Exit if we can't create the enum
             if enum_id == None:
-                idaapi.msg("ERROR: Unable to create or find enum: %s\n" % ENUM_NAME)
+                idaapi.msg("ERROR: Unable to create or find enum: %s\n" % generate_enum_name(ENUM_PREFIX))
                 return
             # Make value an enum
             ida_bytes.op_enum(ea, 0, enum_id, 0)

--- a/hashdb.py
+++ b/hashdb.py
@@ -628,15 +628,15 @@ Do you want to import all function hashes from this module?
 #--------------------------------------------------------------------------
 # IDA helper functions
 #--------------------------------------------------------------------------
-def add_enums(enum_name, hash_list, enum_member_prefix = None, enum_size = 0):
+def add_enums(enum_name, hash_list, enum_member_suffix = None, enum_size = 0):
     '''
     Add a list of string,hash pairs to enum.
     hash_list = [(string1,hash1),(string2,hash2)]
     '''
     # Resolve the enum member prefix
-    if enum_member_prefix is None:
+    if enum_member_suffix is None:
         global HASHDB_ALGORITHM
-        enum_member_prefix = HASHDB_ALGORITHM
+        enum_member_suffix = HASHDB_ALGORITHM
     # Resolve the enum size
     if not enum_size:
         global HASHDB_ALGORITHM_SIZE
@@ -655,7 +655,7 @@ def add_enums(enum_name, hash_list, enum_member_prefix = None, enum_size = 0):
         return None
     
     for member_name, value in hash_list:
-        ida_enum.add_enum_member(enum_id, member_name if enum_member_prefix is None else enum_member_prefix + '_' + member_name, value)
+        ida_enum.add_enum_member(enum_id, member_name if enum_member_suffix is None else member_name + '_' + enum_member_suffix, value)
     return enum_id
 
 

--- a/hashdb.py
+++ b/hashdb.py
@@ -628,19 +628,28 @@ Do you want to import all function hashes from this module?
 #--------------------------------------------------------------------------
 # IDA helper functions
 #--------------------------------------------------------------------------
-def add_enums(enum_name, hash_list):
+def add_enums(enum_name, hash_list, enum_size = 0):
     '''
     Add a list of string,hash pairs to enum.
     hash_list = [(string1,hash1),(string2,hash2)]
     '''
+    # Resolve the enum size
+    if not enum_size:
+        global HASHDB_ALGORITHM_SIZE
+        enum_size = int(HASHDB_ALGORITHM_SIZE / 8)
+
     # Create enum
-    enum_id = idc.add_enum(-1, enum_name, ida_bytes.dec_flag())
+    enum_id = idc.add_enum(-1, enum_name, ida_bytes.hex_flag())
     if enum_id == idaapi.BADNODE:
         # Enum already exists attempt to find it
         enum_id = ida_enum.get_enum(enum_name)
     if enum_id == idaapi.BADNODE:
         # Can't create or find enum
         return None
+    # Set the enum size/width (expected to return True for valid sizes)
+    if not ida_enum.set_enum_width(enum_id, enum_size):
+        return None
+    
     for element in hash_list:
         ida_enum.add_enum_member(enum_id, element[0], element[1])
     return enum_id

--- a/hashdb.py
+++ b/hashdb.py
@@ -655,8 +655,7 @@ def add_enums(enum_name, hash_list, enum_member_prefix = None, enum_size = 0):
         return None
     
     for member_name, value in hash_list:
-        # if not enum_member_prefix was specifically chosen to allow empty prefixes
-        ida_enum.add_enum_member(enum_id, member_name if not enum_member_prefix else enum_member_prefix + '_' + member_name, value)
+        ida_enum.add_enum_member(enum_id, member_name if enum_member_prefix is None else enum_member_prefix + '_' + member_name, value)
     return enum_id
 
 
@@ -1009,7 +1008,7 @@ def hash_scan(convert_values = True):
     if HASHDB_ALGORITHM == None:
         warn_result = idaapi.warning("Please select a hash algorithm before using HashDB.")
         settings_results = hashdb_settings_t.show(api_url=HASHDB_API_URL, 
-                                                  enum_name=generate_enum_name(ENUM_PREFIX),
+                                                  enum_prefix=ENUM_PREFIX,
                                                   use_xor=HASHDB_USE_XOR,
                                                   xor_value=HASHDB_XOR_VALUE,
                                                   algorithms=[])

--- a/hashdb.py
+++ b/hashdb.py
@@ -657,7 +657,7 @@ def add_enums(enum_name, hash_list, enum_size = 0):
     MAXIMUM_ATTEMPTS = 256 # ENUM_MEMBER_ERROR_VALUE -> only allows 256 members with this value
     for member_name, value in hash_list:
         # First, we have to check if this name and value already exist in the enum
-        if ida_enum.get_enum_member(enum_id, value, 0, -1) != idaapi.BADNODE:
+        if ida_enum.get_enum_member(enum_id, value, 0, 0) != idaapi.BADNODE:
             continue # Skip if the value already exists in the enum
 
         # Attempt to generate a name, and insert the value


### PR DESCRIPTION
This PR is in reference to issue #13.
For detailed information please read the commit messages.

Known bugs:
- 32-bit IDA can't add 64-bit hash values to enums (`ida_enum.add_enum_member` is broken, I'll contact Hex-Rays about it).