### PR TITLE
Exception handling support

### DIFF
--- a/hashdb.py
+++ b/hashdb.py
@@ -1271,7 +1271,6 @@ def determine_algorithm_size(algorithm_type: str) -> str:
 # Set xor key
 #--------------------------------------------------------------------------
 def set_xor_key():
-    raise HashDBError("error")
     """
     Set xor key from selection
     """

--- a/hashdb.py
+++ b/hashdb.py
@@ -72,6 +72,7 @@ def hashdb_exception_hook(exception_type, value, traceback_object):
         "user_data": {
             "platform": sys.platform,
             "python_version": '.'.join([str(sys.version_info.major), str(sys.version_info.minor), str(sys.version_info.micro)]),
+            "plugin_version": VERSION,
             "ida": {
                 "kernel_version": ida_kernwin.get_kernel_version(),
                 "bits": 32 if not idaapi.get_inf_structure().is_64bit() else 64
@@ -93,7 +94,6 @@ def hashdb_exception_hook(exception_type, value, traceback_object):
         # Save frame data
         frame_data["frames"].append({
             "frame_index": frame_index,
-            "plugin_version": VERSION,
             "line_number": frame_summary.lineno,
             "function_name": frame_summary.name,
             "line": frame_summary.line,

--- a/hashdb.py
+++ b/hashdb.py
@@ -66,6 +66,7 @@ assert (sys.version_info >= (3, 6)), "ERROR: HashDB plugin requires Python 3.6"
 #--------------------------------------------------------------------------
 # Global exception hook to detect plugin exceptions until
 #  we implement a proper test-driven development setup
+# Note: minimum Python version support is 3.5 
 #--------------------------------------------------------------------------
 HASHDB_REPORT_BUG_URL = "https://github.com/OALabs/hashdb-ida/issues/new"
 def hashdb_exception_hook(exception_type, value, traceback_object):
@@ -86,7 +87,7 @@ def hashdb_exception_hook(exception_type, value, traceback_object):
             "exception_value": str(value)
         },
         "frames": []}
-    frame_summaries = traceback.extract_tb(traceback_object)
+    frame_summaries = traceback.StackSummary.extract(traceback.walk_tb(traceback_object), capture_locals=True)
     for frame_index, frame_summary in enumerate(frame_summaries):
         file_name = frame_summary.filename
         if "__file__" in globals():

--- a/hashdb.py
+++ b/hashdb.py
@@ -64,6 +64,7 @@ assert (sys.version_info >= (3, 6)), "ERROR: HashDB plugin requires Python 3.6"
 # Global exception hook to detect plugin exceptions until
 #  we implement a proper test-driven development setup
 #--------------------------------------------------------------------------
+HASHDB_REPORT_BUG_URL = ""
 def hashdb_exception_hook(exception_type, value, traceback_object):
     is_hashdb_exception = False
 
@@ -125,8 +126,8 @@ def hashdb_exception_hook(exception_type, value, traceback_object):
 
         # Did the user allow us to submit a request?
         if button_selected == 1: # Yes button
-            API_URL = ""
-            requests.post(API_URL, {
+            global HASHDB_REPORT_BUG_URL
+            requests.post(HASHDB_REPORT_BUG_URL, {
                 "username": "HashDB-IDA Error",
                 "content": "```json\n{}```".format(json.dumps(frame_data, indent=4))
             })

--- a/hashdb.py
+++ b/hashdb.py
@@ -139,7 +139,6 @@ sys.excepthook = hashdb_exception_hook
 # Rest of the imports
 import functools
 import string
-import traceback
 from typing import Union
 
 # These imports are specific to the Worker implementation
@@ -151,7 +150,6 @@ from enum import Enum
 from threading import Thread
 from collections.abc import Iterable
 from typing import Awaitable, Callable
-from asyncio.events import AbstractEventLoop
 from asyncio.exceptions import CancelledError, TimeoutError
 
 #--------------------------------------------------------------------------

--- a/hashdb.py
+++ b/hashdb.py
@@ -109,7 +109,7 @@ def hashdb_exception_hook(exception_type, value, traceback_object):
                         <p style="margin: 0; font-size: 12px">Would you like to submit a stack trace to the developers?</p>
                         <br>
                         <p style="margin: 0; font-size: 10px"><i><b>Selecting "Yes" will submit a request to our servers.</b></i></p>
-                        <p style="margin: 0; font-size: 10px"><i><b>All personally identifiable information will not be removed.</b></i></p>
+                        <p style="margin: 0; font-size: 10px"><i><b>All personally identifiable information will be removed.</b></i></p>
                     </center>""", super().FT_HTML_LABEL)
                 }
                 super().__init__(form, controls)


### PR DESCRIPTION
Added a fancy popup dialogue whenever an exception occurs and is caused by the `hashdb-ida` plugin.

The PR adds a global exception handler (see the note [here](https://github.com/anthonyprintup/hashdb-ida/blob/6c5e81005b457c2070ba3a957ba1d0b912c9a7c0/hashdb.py#L63-L66)) which pops up whenever the plugin throws an unhandled exception. The user can then decide if they want to submit a report or not.

> **To make sure initialization works, some parts of the code had to be moved.**

## Recent changes:
- the bug reports no longer rely on Discord webhooks - switched to GitHub's issues feature.

## Previews:
An unhandled exception occurred:
![image](https://user-images.githubusercontent.com/92564080/141069149-29826299-c39e-46fd-b175-f64c7a751fa6.png)
After the user decides to report the bug:
![image](https://user-images.githubusercontent.com/92564080/141069223-3ba05991-c12d-44d9-86f7-5a6a3458af24.png)

## Privacy concerns:
Only the minimal amount of information is provided.
![image](https://user-images.githubusercontent.com/92564080/141052806-30aefde3-ec41-40c2-a57c-a374c666e8c8.png)