### PR TITLE
Fix potential unqualified enum identifiers 

### DIFF
--- a/hashdb.py
+++ b/hashdb.py
@@ -1038,6 +1038,26 @@ def get_invalid_characters(string: str) -> list:
     return invalid_characters
 
 
+def html_format_invalid_characters(string: str, color: str = "#F44336") -> str:
+    invalid_characters = get_invalid_characters(string)
+    
+    # Are there any invalid characters in the string?
+    if not invalid_characters:
+        return string
+    
+    
+    # Format the invalid characters
+    formatted_string = ""
+    for index, character in enumerate(string):
+        if index in invalid_characters and color:
+            formatted_string += "<span style=\"color: {}\">{}<span>".format(color, character)
+        else:
+            formatted_string += character
+
+    # Return the formatted string
+    return formatted_string
+
+
 def add_enums(enum_name, hash_list, enum_size = 0):
     '''
     Add a list of string,hash pairs to enum.

--- a/hashdb.py
+++ b/hashdb.py
@@ -1038,19 +1038,16 @@ def get_invalid_characters(string: str) -> list:
     return invalid_characters
 
 
-def html_format_invalid_characters(string: str, color: str = "#F44336") -> str:
-    invalid_characters = get_invalid_characters(string)
-    
+def html_format_invalid_characters(string: str, invalid_characters: list, color: str = "#F44336") -> str:
     # Are there any invalid characters in the string?
     if not invalid_characters:
         return string
-    
     
     # Format the invalid characters
     formatted_string = ""
     for index, character in enumerate(string):
         if index in invalid_characters and color:
-            formatted_string += "<span style=\"color: {}\">{}<span>".format(color, character)
+            formatted_string += "<span style=\"color: {}\">{}</span>".format(color, character)
         else:
             formatted_string += character
 

--- a/hashdb.py
+++ b/hashdb.py
@@ -1019,6 +1019,17 @@ Do you want to import all function hashes from this module?
 #--------------------------------------------------------------------------
 def get_invalid_characters(string: str) -> list:
     invalid_characters = []
+    # Is the string empty?
+    if not string:
+        return invalid_characters
+
+    # Is the first character a digit?
+    if string[0].isdigit():
+        invalid_characters.append({
+            "index": 0,
+            "char": string[0]
+        })
+
     # Iterate through the characters in the string,
     #  and check if they are valid using
     #  ida_name.is_ident_cp

--- a/hashdb.py
+++ b/hashdb.py
@@ -1170,7 +1170,7 @@ def add_enums(enum_name, hash_list, enum_size = 0):
             # Check if the user provided an invalid name
             invalid_characters = get_invalid_characters(member_name)
         if skip:
-            idaapi.msg("HashDB: Skipping hash result \"{}\" with value: {}".format(member_name, hex(value)))
+            idaapi.msg("HashDB: Skipping hash result \"{}\" with value: {}\n".format(member_name, hex(value)))
             continue
 
         # Attempt to generate a name, and insert the value

--- a/hashdb.py
+++ b/hashdb.py
@@ -1025,20 +1025,14 @@ def get_invalid_characters(string: str) -> list:
 
     # Is the first character a digit?
     if string[0].isdigit():
-        invalid_characters.append({
-            "index": 0,
-            "char": string[0]
-        })
+        invalid_characters.append(0)
 
     # Iterate through the characters in the string,
     #  and check if they are valid using
     #  ida_name.is_ident_cp
     for index, character in enumerate(string):
         if not ida_name.is_ident_cp(ord(character)):
-            invalid_characters.append({
-                "index": index,
-                "char": character
-            })
+            invalid_characters.append(index)
 
     # Return the invalid characters
     return invalid_characters

--- a/hashdb.py
+++ b/hashdb.py
@@ -1059,10 +1059,12 @@ def html_format_invalid_characters(string: str, color: str = "#F44336") -> str:
 
 
 def add_enums(enum_name, hash_list, enum_size = 0):
-    '''
-    Add a list of string,hash pairs to enum.
-    hash_list = [(string1,hash1),(string2,hash2)]
-    '''
+    """
+    Adds a hash list to an enum by name.
+
+    The hash list should be a list of tuples with three values:
+     name: str, value: int, is_api: bool
+    """
     # Resolve the enum size
     if not enum_size:
         global HASHDB_ALGORITHM_SIZE

--- a/hashdb.py
+++ b/hashdb.py
@@ -45,6 +45,7 @@ import sys
 import idaapi
 import idc
 import ida_kernwin
+import ida_name
 import ida_enum
 import ida_bytes
 import ida_netnode
@@ -1016,6 +1017,22 @@ Do you want to import all function hashes from this module?
 #--------------------------------------------------------------------------
 # IDA helper functions
 #--------------------------------------------------------------------------
+def get_invalid_characters(string: str) -> list:
+    invalid_characters = []
+    # Iterate through the characters in the string,
+    #  and check if they are valid using
+    #  ida_name.is_ident_cp
+    for index, character in enumerate(string):
+        if not ida_name.is_ident_cp(ord(character)):
+            invalid_characters.append({
+                "index": index,
+                "char": character
+            })
+
+    # Return the invalid characters
+    return invalid_characters
+
+
 def add_enums(enum_name, hash_list, enum_size = 0):
     '''
     Add a list of string,hash pairs to enum.


### PR DESCRIPTION
Fixes #17.

To fix hashes with "special characters" we have to ask the user to manually rename the enum identifier (`member_name`).
This PR adds a new IDA form `unqualified_name_replace_t` to the plugin, which is used when an invalid name is encountered.

To check whether a name is valid we use [ida_name.is_ident_cp](https://hex-rays.com/products/ida/support/idapython_docs/ida_name.html#ida_name.is_ident_cp), which automatically checks all available character sets (including uncommon Chinese characters, etc.).

For more information please check the commits.
Tested with 32-bit and 64-bit IDA 7.6 running Python 3.10.0

## Preview:
![9vqvR17fpf](https://user-images.githubusercontent.com/92564080/141291362-dd8762e3-6c3e-4680-91d8-3a0b814145a2.gif)