### PR TITLE
handle read timeout for requests when hunt for algo

### DIFF
--- a/hashdb.py
+++ b/hashdb.py
@@ -1732,7 +1732,7 @@ def hunt_algorithm_request(hash_value: int, timeout=None) -> Union[None, list]:
     try:
         # Send the hunt request
         match_results = hunt_hash(hash_value, api_url=HASHDB_API_URL, timeout=timeout)
-    except requests.exceptions.Timeout:
+    except (requests.exceptions.Timeout, requests.exceptions.ReadTimeout):
         idaapi.msg("ERROR: HashDB API hunt hash request timed out.\n")
         logging.exception("API request to {} timed out.".format(HASHDB_API_URL))
         return None
@@ -1744,7 +1744,7 @@ def hunt_algorithm_request(hash_value: int, timeout=None) -> Union[None, list]:
     try:
         # Send the hunt request
         algorithms = get_algorithms(timeout=timeout)
-    except requests.exceptions.Timeout:
+    except (requests.exceptions.Timeout, requests.exceptions.ReadTimeout):
         idaapi.msg("ERROR: HashDB API algorithms request timed out.\n")
         logging.exception("API request to {} timed out.".format(HASHDB_API_URL))
         return None


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/Applications/IDA Pro 7.7/ida.app/Contents/MacOS/plugins/hashdb.py", line 1734, in hunt_algorithm_request
    match_results = hunt_hash(hash_value, api_url=HASHDB_API_URL, timeout=timeout)
  File "/Applications/IDA Pro 7.7/ida.app/Contents/MacOS/plugins/hashdb.py", line 432, in hunt_hash
    r = requests.post(module_url, json={"hashes": hash_list}, timeout=timeout)
  File "/usr/local/Cellar/python@3.9/3.9.10/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/requests/api.py", line 117, in post
    return request('post', url, data=data, json=json, **kwargs)
  File "/usr/local/Cellar/python@3.9/3.9.10/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/requests/api.py", line 61, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/local/Cellar/python@3.9/3.9.10/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/requests/sessions.py", line 529, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/Cellar/python@3.9/3.9.10/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/requests/sessions.py", line 645, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/Cellar/python@3.9/3.9.10/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/requests/adapters.py", line 532, in send
    raise ReadTimeout(e, request=request)
requests.exceptions.ReadTimeout: HTTPSConnectionPool(host='hashdb.openanalysis.net', port=443): Read timed out. (read timeout=15)
```