### PR TITLE
Fixed issue #41

### DIFF
--- a/hashdb.py
+++ b/hashdb.py
@@ -559,6 +559,7 @@ HashDB Settings
 
     def OnBtnRefresh(self, code=0):
         api_url = self.GetControlValue(self.iServer)
+        algorithms = []
         try:
             ida_kernwin.show_wait_box("HIDECANCEL\nPlease wait...")
             algorithms = get_algorithms(api_url=api_url)


### PR DESCRIPTION
When generating the list of algorithms from the API, if the call to `get_algorithms` raised an exception, algorithms wouldn't be assigned.

Resolves issue #41 