### PR TITLE
Fixed highlighted value parsing

### DIFF
--- a/hashdb.py
+++ b/hashdb.py
@@ -1052,7 +1052,7 @@ def parse_highlighted_value():
         raise HashDBError("Invalid selection; did you manually range-select a value, or double-click a value?")
 
     # Handle various number formats
-    match = re.match(r"^(?P<sign>[-+])?(?P<prefix>0|0x)?(?P<number>[0-9A-F]+)(?P<suffix>b|h|u|i64|ui64)?$",
+    match = re.match(r"^(?P<sign>[-+])?(?P<prefix>0|0x)?(?P<number>[0-9A-F]+)(?P<suffix>b|o|h|u|i64|ui64)?$",
                      identifier)
     if match is None:
         raise HashDBError(f"Failed to parse the value {identifier!r}, please submit a bug report.")
@@ -1065,7 +1065,7 @@ def parse_highlighted_value():
     radix = 10
     if suffix == "b":
         radix = 2  # binary
-    elif prefix == "0" and not suffix == "h":
+    elif suffix == "o" or prefix == "0" and not suffix == "h":
         radix = 8  # octal
     elif prefix == "0x" or suffix == "h":
         radix = 16  # hexadecimal

--- a/hashdb.py
+++ b/hashdb.py
@@ -172,9 +172,9 @@ def hashdb_exception_hook(exception_type, value, traceback_object):
 sys.excepthook = hashdb_exception_hook
 
 # Rest of the imports
+import re
 import functools
 import requests
-import string
 from typing import Union
 
 # These imports are specific to the Worker implementation
@@ -1036,54 +1036,45 @@ def make_const_enum(enum_id, hash_value):
         ida_bytes.op_enum(start, 0, enum_id, 0)
 
 
+# TODO: add exception handling around this call
 def parse_highlighted_value():
-    identifier = None
+    current_viewer = ida_kernwin.get_current_viewer()
+    is_range_selected, _, _ = ida_kernwin.read_range_selection(current_viewer)
+    if is_range_selected:
+        raise HashDBError("Ranged selections are not supported when parsing highlighted values. "
+                          "Were multiple lines selected?")
 
-    v = ida_kernwin.get_current_viewer()
-    thing = ida_kernwin.get_highlight(v)
-    if thing and thing[1]:
-        identifier = thing[0]
-    if identifier is None:
-        return None
+    highlight_result = ida_kernwin.get_highlight(current_viewer)
+    if highlight_result is None:
+        raise HashDBError("Invalid selection; nothing was selected.")
 
-    # Represents the type of the value
-    type = "decimal"
-    if identifier.endswith('h'):
-        # IDA View
-        identifier = identifier[:-1]
-        type = "hex"
-    elif identifier.startswith("0x"):
-        # Pseudocode
-        identifier = identifier[2:]
-        type = "hex"
-    elif identifier.endswith('o'):
-        identifier = identifier[:-1]
-        type = "octal"
-    elif identifier.endswith('b'):
-        identifier = identifier[:-1]
-        type = "binary"
-    
-    character_set = {
-        "binary": "01",
-        "octal": string.octdigits,
-        "decimal": string.digits,
-        "hex": string.hexdigits
-    }
-    # Find the first invalid character and trim the string accordingly
-    for index, character in enumerate(identifier):
-        if character not in character_set[type]:
-            identifier = identifier[:index]
-            break
-    if not identifier: # The first character was bad
-        return None
+    identifier, flags = highlight_result
+    if not flags:
+        raise HashDBError("Invalid selection; did you manually range-select a value, or double-click a value?")
 
-    types = {
-        "binary": 2,
-        "octal": 8,
-        "decimal": 10,
-        "hex": 16
-    }
-    return int(identifier, types[type])
+    # Handle various number formats
+    match = re.match(r"^(?P<sign>[-+])?(?P<prefix>0|0x)?(?P<number>[0-9A-F]+)(?P<suffix>b|h|u|i64|ui64)?$",
+                     identifier)
+    if match is None:
+        raise HashDBError(f"Failed to parse the value {identifier!r}, please submit a bug report.")
+
+    # Determine the radix and number value
+    sign, prefix, number, suffix = match.groups()
+    if sign is None:
+        sign = "+"
+
+    radix = 10
+    if suffix == "b":
+        radix = 2  # binary
+    elif prefix == "0" and not suffix == "h":
+        radix = 8  # octal
+    elif prefix == "0x" or suffix == "h":
+        radix = 16  # hexadecimal
+
+    try:
+        return int(f"{sign}{number}", radix)
+    except ValueError:
+        raise HashDBError(f"Failed to parse the value {identifier!r} with a radix of {radix}.")
 
 
 def determine_highlighted_type_size(ea: int) -> int:


### PR DESCRIPTION
## Overview
Fixed cases where the user could perform partial (or ranged) selections, and the Ida API would return unexpected values. As a result the function `parse_highlighted_value` had to be completely refactored:
- the function now raises a `HashDBError` exception if something failed (e.g. parsing),
- we now use regex to match the desired number value.

I've tested the plugin and haven't found any regressions.

## Relevant Issues
- [x] #44 