### PR TITLE
hashdb: Improved enum application + decompiler support

### DIFF
--- a/hashdb.py
+++ b/hashdb.py
@@ -266,11 +266,7 @@ class _ImportManager:
         self.imported_modules = set()
 
     def hash_lookup_done_handler(self, hash_list: Union[None, list], hash_value: int = None):
-        """Bound handler that was previously a free function.
-
-        The implementation is the same as the original `hash_lookup_done_handler`
-        but uses `self.imported_modules` instead of a global.
-        """
+        """Receive, handle, and apply the results of a hash query."""
         global ENUM_PREFIX
         def add_enums_wrapper(enum_name, hash_list):
             nonlocal enum_id

--- a/hashdb.py
+++ b/hashdb.py
@@ -1349,27 +1349,25 @@ def apply_bulk_enums(enum_id, enum_list):
 
     # 3. Iterate instructions
     count = 0
-    curr_ea = func.start_ea
-    while curr_ea < func.end_ea and curr_ea != idaapi.BADADDR:
-        # Check operands 0, 1, 2
-        for op_n in range(3):
-            if idc.get_operand_type(curr_ea, op_n) == idc.o_void:
-                break
-            
-            val = idc.get_operand_value(curr_ea, op_n)
-            
-            # Check match
-            match = False
-            if val in hashes_strict:
-                match = True
-            elif (val & 0xFFFFFFFF) in hashes_32:
-                match = True
-            
-            if match:
-                if ida_bytes.op_enum(curr_ea, op_n, enum_id, 0):
-                    count += 1
-        
-        curr_ea = ida_bytes.next_head(curr_ea, func.end_ea)
+    for chunk_start, chunk_end in idautils.Chunks(func.start_ea):
+        for head in idautils.Heads(chunk_start, chunk_end):
+            # Check operands 0, 1, 2
+            for op_n in range(3):
+                if idc.get_operand_type(head, op_n) == idc.o_void:
+                    break
+                
+                val = idc.get_operand_value(head, op_n)
+                
+                # Check match
+                match = False
+                if val in hashes_strict:
+                    match = True
+                elif (val & 0xFFFFFFFF) in hashes_32:
+                    match = True
+                
+                if match:
+                    if ida_bytes.op_enum(head, op_n, enum_id, 0):
+                        count += 1
         
     return count
 

--- a/hashdb.py
+++ b/hashdb.py
@@ -1129,11 +1129,9 @@ def make_const_enum(enum_id, hash_value, ea=None):
     func = idaapi.get_func(ea)
     total_replacements = 0
     if func:
-        # Iterate over all heads in the function
-        curr_ea = func.start_ea
-        while curr_ea < func.end_ea and curr_ea != idaapi.BADADDR:
-             total_replacements += apply_to_ea(curr_ea)
-             curr_ea = ida_bytes.next_head(curr_ea, func.end_ea)
+        for chunk_start, chunk_end in idautils.Chunks(func.start_ea):
+            for head in idautils.Heads(chunk_start, chunk_end):
+                total_replacements += apply_to_ea(curr_ea)
     else:
         # Not in a function 
         total_replacements += apply_to_ea(ea)


### PR DESCRIPTION
- Cache imported API modules to avoid repeated prompts/requests. (really annoyed me)
- Apply enums across the whole function (operands 0..2, 32-bit mask fallback)
- Add bulk enum apply for imported module hashes + refresh disasm/Hex-Rays views.
- Improve highlighted number parsing (more suffixes, case-insensitive)
- Fix “New name:” form label escaping

TLDR: decompiler support, bulk hash rename, IDA 9.0+ works